### PR TITLE
feat: bump SDK to 2.5.1 and add v7 EventTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Ixo Foundation",
   "license": "Apache 2",
   "dependencies": {
-    "@ixo/impactxclient-sdk": "2.4.2",
+    "@ixo/impactxclient-sdk": "2.5.1",
     "@sentry/node": "7.36.0",
     "@sentry/tracing": "7.36.0",
     "body-parser": "1.20.1",

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -47,13 +47,32 @@ export enum EventTypes {
   authAdded = "ixo.smartaccount.v1beta1.AuthenticatorAddedEvent",
   authRemoved = "ixo.smartaccount.v1beta1.AuthenticatorRemovedEvent",
   authSetActive = "ixo.smartaccount.v1beta1.AuthenticatorSetActiveStateEvent",
-  // liquidstake
+  // liquidstake (v6 + v7)
   lsParamsUpdated = "ixo.liquidstake.v1beta1.LiquidStakeParamsUpdatedEvent",
   lsStake = "ixo.liquidstake.v1beta1.LiquidStakeEvent",
   lsUpstake = "ixo.liquidstake.v1beta1.LiquidUnstakeEvent",
   lsAddLSValidator = "ixo.liquidstake.v1beta1.AddLiquidValidatorEvent",
   lsRebalanced = "ixo.liquidstake.v1beta1.RebalancedLiquidStakeEvent",
   lsAutoCompound = "ixo.liquidstake.v1beta1.AutocompoundStakingRewardsEvent",
+  // liquidstake v7 (new multi-pool typed events)
+  lsModuleParamsUpdated = "ixo.liquidstake.v1beta1.ModuleParamsUpdatedEvent",
+  lsPoolCreated = "ixo.liquidstake.v1beta1.PoolCreatedEvent",
+  lsPoolUpdated = "ixo.liquidstake.v1beta1.PoolUpdatedEvent",
+  // claims v7
+  disputeResolved = "ixo.claims.v1beta1.DisputeResolvedEvent",
+  memberBudgetCreated = "ixo.claims.v1beta1.MemberBudgetCreatedEvent",
+  memberBudgetUpdated = "ixo.claims.v1beta1.MemberBudgetUpdatedEvent",
+  memberBudgetRemoved = "ixo.claims.v1beta1.MemberBudgetRemovedEvent",
+  agentDepositBalanceCreated = "ixo.claims.v1beta1.AgentDepositBalanceCreatedEvent",
+  agentDepositBalanceUpdated = "ixo.claims.v1beta1.AgentDepositBalanceUpdatedEvent",
+  agentDepositBalanceRemoved = "ixo.claims.v1beta1.AgentDepositBalanceRemovedEvent",
+  // names v7
+  namespaceCreated = "ixo.names.v1beta1.NamespaceCreatedEvent",
+  namespaceUpdated = "ixo.names.v1beta1.NamespaceUpdatedEvent",
+  nameRegistered = "ixo.names.v1beta1.NameRegisteredEvent",
+  nameUpdated = "ixo.names.v1beta1.NameUpdatedEvent",
+  nameTransferred = "ixo.names.v1beta1.NameTransferredEvent",
+  nameStatusChanged = "ixo.names.v1beta1.NameStatusChangedEvent",
 }
 
 const EventTypesArray = Object.values(EventTypes) as string[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,10 +196,10 @@
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
   integrity sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==
 
-"@ixo/impactxclient-sdk@2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@ixo/impactxclient-sdk/-/impactxclient-sdk-2.4.2.tgz#57ad30888c75c37a9f68d90c0d3d555436e6bd2e"
-  integrity sha512-4x/2y9ZIJAbsCT4D6NszaOioGOIwWBCb4Pm/e66LNRB+iprgusMzbS5e3koAvejSzTwzixys5JNYjluPeVkMHg==
+"@ixo/impactxclient-sdk@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@ixo/impactxclient-sdk/-/impactxclient-sdk-2.5.1.tgz#c50533f3b8edac448e44a4b5abbe4a0aaa21b4e6"
+  integrity sha512-MQXVi9uvPppbGbF6HjAka4wyIJgCPOJemVb40Sn/JlIljzqSvmihQRUgyhxaS5HrycJlidLaPs2IoL1XDFF6Fg==
   dependencies:
     "@babel/runtime" "7.19.4"
     "@cosmjs/amino" "0.32.4"


### PR DESCRIPTION
  @ixo/impactxclient-sdk 2.4.2 -> 2.5.1 picks up chain-v7 message
  decoding (incl. legacy liquidstake MsgUpdateParams).

  Add EventTypes entries for the v7 typed events so the EventTypesSet
  allowlist doesn't drop them on ingest: liquidstake (ModuleParamsUpdated,
  PoolCreated, PoolUpdated), claims (DisputeResolved, MemberBudget*,
  AgentDepositBalance*), names (Namespace*, Name*).

  Authored by: Michael Pretorius <michael@ixo.world>